### PR TITLE
refactor: unify brand theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,9 @@
 @import "tailwindcss";
 
+/* global color tokens */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0f172a; /* slate-900 */
+  --foreground: #f8fafc; /* slate-50 */
 }
 
 :root {
@@ -12,37 +13,31 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  color-scheme: dark;
 }
 :root {
   --nav-height: 56px;
 }
 
-/* Softer page background and spacing under the navbar */
+/* page background and spacing under the navbar */
 .page-shell {
   min-height: calc(100dvh - var(--nav-height));
   padding: 24px;
   background: radial-gradient(
       1200px 600px at 10% -10%,
-      rgba(99, 102, 241, 0.1),
+      rgba(55, 48, 163, 0.35),
       transparent 40%
     ),
     radial-gradient(
       900px 500px at 100% 0%,
-      rgba(129, 140, 248, 0.08),
+      rgba(55, 48, 163, 0.25),
       transparent 50%
     ),
-    #f7f9fc;
+    var(--background);
 }
 
 /* Center the Authenticator and make it look like a card */
@@ -56,9 +51,10 @@ body {
 .auth-wrap .amplify-authenticator {
   max-width: 420px;
   width: 100%;
-  background: #fff;
+  background: #1f2937; /* slate-800 */
+  color: var(--foreground);
   border-radius: 16px;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
   padding: 12px; /* Authenticator has its own padding; this just softens edges */
 }
 :root {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,12 +34,12 @@ body {
   padding: 24px;
   background: radial-gradient(
       1200px 600px at 10% -10%,
-      rgba(14, 165, 233, 0.1),
+      rgba(99, 102, 241, 0.1),
       transparent 40%
     ),
     radial-gradient(
       900px 500px at 100% 0%,
-      rgba(2, 132, 199, 0.08),
+      rgba(129, 140, 248, 0.08),
       transparent 50%
     ),
     #f7f9fc;
@@ -62,9 +62,9 @@ body {
   padding: 12px; /* Authenticator has its own padding; this just softens edges */
 }
 :root {
-  --amplify-colors-brand-primary-80: #0ea5e9;
-  --amplify-colors-brand-primary-90: #0284c7;
-  --amplify-colors-brand-primary-100: #0369a1;
+  --amplify-colors-brand-primary-80: #6366f1;
+  --amplify-colors-brand-primary-90: #818cf8;
+  --amplify-colors-brand-primary-100: #3730a3;
   --amplify-radii-medium: 12px;
   --amplify-components-button-border-radius: var(--amplify-radii-medium);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,11 +13,16 @@
   --font-mono: var(--font-geist-mono);
 }
 
+html {
+  background: var(--background);
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
   color-scheme: dark;
+  margin: 0;
 }
 :root {
   --nav-height: 56px;
@@ -42,9 +47,10 @@ body {
 
 /* Center the Authenticator and make it look like a card */
 .auth-wrap {
-  min-height: calc(100dvh - var(--nav-height) - 48px);
+  min-height: calc(100dvh - var(--nav-height));
   display: grid;
   place-items: center;
+  background: #1f2937; /* slate-800 to match auth card */
 }
 
 /* style the internal card */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,9 +59,9 @@ export default function Home() {
         components={{
           Header() {
             return (
-              <div style={{ padding: "12px 16px 0" }}>
-                <h3 style={{ margin: 0 }}>Welcome to MediSys</h3>
-                <p style={{ margin: 0, color: "#6b7280", fontSize: 13 }}>
+              <div className="mb-4 text-center">
+                <h3 className="text-lg font-semibold">Welcome to MediSys</h3>
+                <p className="text-sm text-slate-400">
                   Please sign in or create an account
                 </p>
               </div>
@@ -87,14 +87,7 @@ export default function Home() {
           },
           Footer() {
             return (
-              <div
-                style={{
-                  padding: 12,
-                  textAlign: "center",
-                  color: "#9ca3af",
-                  fontSize: 12,
-                }}
-              >
+              <div className="pt-4 text-center text-xs text-slate-500">
                 © {new Date().getFullYear()} MediSys
               </div>
             );
@@ -102,10 +95,17 @@ export default function Home() {
         }}
       >
         {({ signOut, user }) => (
-          <main style={{ padding: 24 }}>
+          <main className="page-shell space-y-4">
             <RoleRedirect />
-            <h1 style={{ marginBottom: 8 }}>Welcome {user?.username}</h1>
-            <button onClick={() => signOut?.()}>Sign out</button>
+            <h1 className="text-2xl font-semibold">
+              Welcome {user?.username}
+            </h1>
+            <button
+              className="self-start rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+              onClick={() => signOut?.()}
+            >
+              Sign out
+            </button>
           </main>
         )}
       </Authenticator>

--- a/src/components/AmplifyThemeProvider.tsx
+++ b/src/components/AmplifyThemeProvider.tsx
@@ -9,9 +9,9 @@ const medisysTheme = createTheme({
       // brand color for buttons/links
       brand: {
         primary: {
-          80: { value: "#0ea5e9" }, // main
-          90: { value: "#0284c7" }, // hover/focus
-          100: { value: "#0369a1" }, // active
+          80: { value: "var(--amplify-colors-brand-primary-80)" }, // main
+          90: { value: "var(--amplify-colors-brand-primary-90)" }, // hover/focus
+          100: { value: "var(--amplify-colors-brand-primary-100)" }, // active
         },
       },
     },

--- a/src/components/AmplifyThemeProvider.tsx
+++ b/src/components/AmplifyThemeProvider.tsx
@@ -6,6 +6,12 @@ const medisysTheme = createTheme({
   name: "medisys",
   tokens: {
     colors: {
+      background: {
+        primary: { value: "var(--background)" },
+      },
+      font: {
+        primary: { value: "var(--foreground)" },
+      },
       // brand color for buttons/links
       brand: {
         primary: {
@@ -49,7 +55,7 @@ export default function AmplifyThemeProvider({
   children: React.ReactNode;
 }) {
   return (
-    <ThemeProvider theme={medisysTheme} colorMode="light">
+    <ThemeProvider theme={medisysTheme} colorMode="dark">
       {children}
     </ThemeProvider>
   );

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -19,6 +19,11 @@ export default function NavBar() {
     (user?.signInDetails?.loginId as string | undefined) ??
     null;
 
+  const buttonGradient =
+    "linear-gradient(90deg, var(--amplify-colors-brand-primary-80) 0%, var(--amplify-colors-brand-primary-90) 100%)";
+  const buttonGradientHover =
+    "linear-gradient(90deg, var(--amplify-colors-brand-primary-90) 0%, var(--amplify-colors-brand-primary-80) 100%)";
+
   const handleLogout = async () => {
     try {
       await signOut(); // Amplify v6 signOut
@@ -41,7 +46,7 @@ export default function NavBar() {
         justifyContent: "space-between",
         padding: "0.75rem 2rem",
         borderBottom: "1px solid #e5e7eb",
-        background: "linear-gradient(90deg, #f8fafc 0%, #e0e7ff 100%)",
+        background: "linear-gradient(90deg, #f8fafc 0%, #eef2ff 100%)",
         boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
       }}
     >
@@ -49,7 +54,7 @@ export default function NavBar() {
         href="/"
         style={{
           textDecoration: "none",
-          color: "#3730a3",
+          color: "var(--amplify-colors-brand-primary-100)",
           fontWeight: 700,
           fontSize: 22,
           letterSpacing: 1,
@@ -65,7 +70,12 @@ export default function NavBar() {
           fill="none"
           style={{ marginRight: 6 }}
         >
-          <rect width="24" height="24" rx="6" fill="#6366f1" />
+          <rect
+            width="24"
+            height="24"
+            rx="6"
+            fill="var(--amplify-colors-brand-primary-80)"
+          />
           <path
             d="M12 7v10M7 12h10"
             stroke="#fff"
@@ -82,7 +92,7 @@ export default function NavBar() {
             <span
               style={{
                 fontSize: 15,
-                color: "#6366f1",
+                color: "var(--amplify-colors-brand-primary-80)",
                 background: "#eef2ff",
                 padding: "0.3rem 0.8rem",
                 borderRadius: 20,
@@ -98,7 +108,7 @@ export default function NavBar() {
                 padding: "0.45rem 1.1rem",
                 borderRadius: 8,
                 border: "none",
-                background: "linear-gradient(90deg, #6366f1 0%, #818cf8 100%)",
+                background: buttonGradient,
                 color: "#fff",
                 fontWeight: 600,
                 fontSize: 15,
@@ -108,11 +118,11 @@ export default function NavBar() {
               }}
               onMouseOver={(e) =>
                 ((e.target as HTMLButtonElement).style.background =
-                  "linear-gradient(90deg, #818cf8 0%, #6366f1 100%)")
+                  buttonGradientHover)
               }
               onMouseOut={(e) =>
                 ((e.target as HTMLButtonElement).style.background =
-                  "linear-gradient(90deg, #6366f1 0%, #818cf8 100%)")
+                  buttonGradient)
               }
             >
               Logout
@@ -125,7 +135,7 @@ export default function NavBar() {
               padding: "0.45rem 1.1rem",
               borderRadius: 8,
               border: "none",
-              background: "linear-gradient(90deg, #6366f1 0%, #818cf8 100%)",
+              background: buttonGradient,
               color: "#fff",
               fontWeight: 600,
               fontSize: 15,
@@ -136,11 +146,11 @@ export default function NavBar() {
             }}
             onMouseOver={(e) =>
               ((e.target as HTMLAnchorElement).style.background =
-                "linear-gradient(90deg, #818cf8 0%, #6366f1 100%)")
+                buttonGradientHover)
             }
             onMouseOut={(e) =>
               ((e.target as HTMLAnchorElement).style.background =
-                "linear-gradient(90deg, #6366f1 0%, #818cf8 100%)")
+                buttonGradient)
             }
           >
             Sign in

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -45,16 +45,16 @@ export default function NavBar() {
         alignItems: "center",
         justifyContent: "space-between",
         padding: "0.75rem 2rem",
-        borderBottom: "1px solid #e5e7eb",
-        background: "linear-gradient(90deg, #f8fafc 0%, #eef2ff 100%)",
-        boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
+        borderBottom: "1px solid #1e293b",
+        background: "linear-gradient(90deg, #1e1b4b 0%, #312e81 100%)",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.5)",
       }}
     >
       <Link
         href="/"
         style={{
           textDecoration: "none",
-          color: "var(--amplify-colors-brand-primary-100)",
+          color: "#f8fafc",
           fontWeight: 700,
           fontSize: 22,
           letterSpacing: 1,
@@ -92,8 +92,8 @@ export default function NavBar() {
             <span
               style={{
                 fontSize: 15,
-                color: "var(--amplify-colors-brand-primary-80)",
-                background: "#eef2ff",
+                color: "var(--amplify-colors-brand-primary-90)",
+                background: "rgba(129,140,248,0.15)",
                 padding: "0.3rem 0.8rem",
                 borderRadius: 20,
                 fontWeight: 500,
@@ -113,7 +113,7 @@ export default function NavBar() {
                 fontWeight: 600,
                 fontSize: 15,
                 cursor: "pointer",
-                boxShadow: "0 1px 4px rgba(99,102,241,0.08)",
+                boxShadow: "0 1px 4px rgba(0,0,0,0.5)",
                 transition: "background 0.2s",
               }}
               onMouseOver={(e) =>
@@ -140,7 +140,7 @@ export default function NavBar() {
               fontWeight: 600,
               fontSize: 15,
               textDecoration: "none",
-              boxShadow: "0 1px 4px rgba(99,102,241,0.08)",
+              boxShadow: "0 1px 4px rgba(0,0,0,0.5)",
               transition: "background 0.2s",
               display: "inline-block",
             }}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -24,8 +24,8 @@ export default function NavBar() {
   const buttonGradientHover =
     "linear-gradient(90deg, var(--amplify-colors-brand-primary-90) 0%, var(--amplify-colors-brand-primary-80) 100%)";
 
-  const handleLogout = () => {
-    signOut();
+  const handleLogout = async () => {
+    await signOut();
     router.replace("/");
   };
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -24,12 +24,9 @@ export default function NavBar() {
   const buttonGradientHover =
     "linear-gradient(90deg, var(--amplify-colors-brand-primary-90) 0%, var(--amplify-colors-brand-primary-80) 100%)";
 
-  const handleLogout = async () => {
-    try {
-      await signOut(); // Amplify v6 signOut
-    } finally {
-      router.replace("/");
-    }
+  const handleLogout = () => {
+    signOut();
+    router.replace("/");
   };
 
   // Optional: avoid brief flicker while Amplify initializes


### PR DESCRIPTION
## Summary
- align brand colors across Amplify theme, global styles, and navigation
- consolidate button gradient logic for consistent UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9b325ad2883289bfb42b89510ce8c